### PR TITLE
Test/sending queue otlp

### DIFF
--- a/testbed/testbed/results.go
+++ b/testbed/testbed/results.go
@@ -34,6 +34,12 @@ type benchmarkResult struct {
 	Extra string  `json:"extra,omitempty"`
 }
 
+type LogPresentResults struct {
+	testName string
+	result   string
+	duration time.Duration
+}
+
 // PerformanceResults implements the TestResultsSummary interface with fields suitable for reporting
 // performance test results.
 type PerformanceResults struct {

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -326,8 +326,8 @@ func (tc *TestCase) logStatsOnce() {
 }
 
 // Used to search for text in agent.log
-// It can be used to verify if we've hit QueuedRetry sender or memory limitter
-func (tc *TestCase) SearchText(text string) bool {
+// It can be used to verify if we've hit QueuedRetry sender or memory limiter
+func (tc *TestCase) AgentLogsContains(text string) bool {
 	filename := tc.composeTestResultFileName("agent.log")
 	cmd := exec.Command("cat", filename)
 	grep := exec.Command("grep", "-E", text)

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -40,7 +40,7 @@ func (v *LogPresentValidator) Validate(tc *TestCase) {
 		successMsg = fmt.Sprintf("Log '%s' not found", logMsg)
 	}
 
-	if assert.True(tc.t, tc.SearchText(logMsg) == v.Present, errorMsg) {
+	if assert.True(tc.t, tc.AgentLogsContains(logMsg) == v.Present, errorMsg) {
 		log.Print(successMsg)
 	}
 }

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -24,6 +24,46 @@ type TestCaseValidator interface {
 	RecordResults(tc *TestCase)
 }
 
+type LogPresentValidator struct {
+	LogBody string
+	Present bool
+}
+
+func (v *LogPresentValidator) Validate(tc *TestCase) {
+	logMsg := v.LogBody
+	var successMsg, errorMsg string
+	if v.Present == true {
+		successMsg = fmt.Sprintf("Log '%s' found", logMsg)
+		errorMsg = fmt.Sprintf("Log '%s' not found", logMsg)
+	} else {
+		errorMsg = fmt.Sprintf("Log '%s' found", logMsg)
+		successMsg = fmt.Sprintf("Log '%s' not found", logMsg)
+	}
+
+	if assert.True(tc.t, tc.SearchText(logMsg) == v.Present, errorMsg) {
+		log.Printf(successMsg)
+	}
+}
+
+func (v *LogPresentValidator) RecordResults(tc *TestCase) {
+
+	var result string
+	if tc.t.Failed() {
+		result = "FAIL"
+	} else {
+		result = "PASS"
+	}
+
+	// Remove "Test" prefix from test name.
+	testName := tc.t.Name()[4:]
+
+	tc.resultsSummary.Add(tc.t.Name(), &LogPresentResults{
+		testName: testName,
+		result:   result,
+		duration: time.Since(tc.startTime),
+	})
+}
+
 // PerfTestValidator implements TestCaseValidator for test suites using PerformanceResults for summarizing results.
 type PerfTestValidator struct{}
 

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -32,7 +32,7 @@ type LogPresentValidator struct {
 func (v *LogPresentValidator) Validate(tc *TestCase) {
 	logMsg := v.LogBody
 	var successMsg, errorMsg string
-	if v.Present == true {
+	if v.Present {
 		successMsg = fmt.Sprintf("Log '%s' found", logMsg)
 		errorMsg = fmt.Sprintf("Log '%s' not found", logMsg)
 	} else {
@@ -41,7 +41,7 @@ func (v *LogPresentValidator) Validate(tc *TestCase) {
 	}
 
 	if assert.True(tc.t, tc.SearchText(logMsg) == v.Present, errorMsg) {
-		log.Printf(successMsg)
+		log.Print(successMsg)
 	}
 }
 

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -8,12 +8,13 @@ package tests // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"fmt"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"math/rand"
 	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -357,7 +358,7 @@ func ScenarioSendingQueuesFull(
 	// searchFunc checks for "sending_queue is full" communicate and sends the signal to GenerateNonPernamentErrorUntil
 	// to generate only successes from that time on
 	tc.WaitForN(func() bool {
-		logFound := tc.SearchText("sending_queue is full") == true
+		logFound := tc.SearchText("sending_queue is full")
 		if !logFound {
 			dataChannel <- true
 			return false
@@ -374,10 +375,10 @@ func ScenarioSendingQueuesFull(
 
 	tc.WaitForN(func() bool {
 		// get IDs from logs to retry
-		logsToRetry := getLogsId(tc.MockBackend.LogsToRetry)
+		logsToRetry := getLogsID(tc.MockBackend.LogsToRetry)
 
 		// get IDs from logs received successfully
-		successfulLogs := getLogsId(tc.MockBackend.ReceivedLogs)
+		successfulLogs := getLogsID(tc.MockBackend.ReceivedLogs)
 
 		// check if all the logs to retry were actually retried
 		logsWereRetried := allElementsExistInSlice(logsToRetry, successfulLogs)
@@ -455,7 +456,7 @@ func constructLoadOptions(test TestCase) testbed.LoadOptions {
 	return options
 }
 
-func getLogsId(logToRetry []plog.Logs) []string {
+func getLogsID(logToRetry []plog.Logs) []string {
 	var result []string
 	for _, logElement := range logToRetry {
 		logRecord := logElement.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -14,10 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/collector/pdata/plog"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -8,10 +8,12 @@ package tests // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"fmt"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"math/rand"
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -305,6 +307,142 @@ func ScenarioTestTraceNoBackend10kSPS(
 	assert.Less(t, configuration.ExpectedMinFinalRAM, rss)
 }
 
+func ScenarioSendingQueuesFull(
+	t *testing.T,
+	sender testbed.DataSender,
+	receiver testbed.DataReceiver,
+	loadOptions testbed.LoadOptions,
+	resourceSpec testbed.ResourceSpec,
+	sleepTime int,
+	resultsSummary testbed.TestResultsSummary,
+	processors map[string]string,
+	extensions map[string]string,
+) {
+	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
+	require.NoError(t, err)
+
+	agentProc := testbed.NewChildProcessCollector()
+
+	configStr := createConfigYaml(t, sender, receiver, resultDir, processors, extensions)
+	configCleanup, err := agentProc.PrepareConfig(configStr)
+	require.NoError(t, err)
+	defer configCleanup()
+	dataProvider := testbed.NewPerfTestDataProvider(loadOptions)
+	dataChannel := make(chan bool)
+	tc := testbed.NewTestCase(
+		t,
+		dataProvider,
+		sender,
+		receiver,
+		agentProc,
+		&testbed.LogPresentValidator{
+			LogBody: "sending_queue is full",
+			Present: true,
+		},
+		resultsSummary,
+		testbed.WithResourceLimits(resourceSpec),
+		testbed.WithDecisionFunc(func() error { return testbed.GenerateNonPernamentErrorUntil(dataChannel) }),
+	)
+
+	tc.MockBackend.EnableRecording()
+	defer tc.Stop()
+
+	tc.StartBackend()
+	tc.StartAgent()
+
+	tc.StartLoad(loadOptions)
+
+	tc.WaitForN(func() bool { return tc.LoadGenerator.DataItemsSent() > 0 }, time.Second*time.Duration(sleepTime), "load generator started")
+
+	// searchFunc checks for "sending_queue is full" communicate and sends the signal to GenerateNonPernamentErrorUntil
+	// to generate only successes from that time on
+	tc.WaitForN(func() bool {
+		logFound := tc.SearchText("sending_queue is full") == true
+		if !logFound {
+			dataChannel <- true
+			return false
+		}
+		tc.WaitFor(func() bool { return tc.MockBackend.DataItemsReceived() == 0 }, "any data items received successfully")
+		close(dataChannel)
+		return logFound
+	}, time.Second*time.Duration(sleepTime), "sending_queue errors present")
+
+	// check if data started to be received successfully
+	tc.WaitForN(func() bool {
+		return tc.MockBackend.DataItemsReceived() > 0
+	}, time.Second*time.Duration(sleepTime), "data was accepted")
+
+	tc.WaitForN(func() bool {
+		// get IDs from logs to retry
+		logsToRetry := getLogsId(tc.MockBackend.LogsToRetry)
+
+		// get IDs from logs received successfully
+		successfulLogs := getLogsId(tc.MockBackend.ReceivedLogs)
+
+		// check if all the logs to retry were actually retried
+		logsWereRetried := allElementsExistInSlice(logsToRetry, successfulLogs)
+		return logsWereRetried
+	}, time.Second*time.Duration(sleepTime), "all logs were retried")
+
+	tc.StopLoad()
+	tc.StopAgent()
+	tc.ValidateData()
+}
+
+func ScenarioSendingQueuesNotFull(
+	t *testing.T,
+	sender testbed.DataSender,
+	receiver testbed.DataReceiver,
+	loadOptions testbed.LoadOptions,
+	resourceSpec testbed.ResourceSpec,
+	sleepTime int,
+	resultsSummary testbed.TestResultsSummary,
+	processors map[string]string,
+	extensions map[string]string,
+) {
+	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
+	require.NoError(t, err)
+
+	agentProc := testbed.NewChildProcessCollector()
+
+	configStr := createConfigYaml(t, sender, receiver, resultDir, processors, extensions)
+	configCleanup, err := agentProc.PrepareConfig(configStr)
+	require.NoError(t, err)
+	defer configCleanup()
+	dataProvider := testbed.NewPerfTestDataProvider(loadOptions)
+	tc := testbed.NewTestCase(
+		t,
+		dataProvider,
+		sender,
+		receiver,
+		agentProc,
+		&testbed.LogPresentValidator{
+			LogBody: "sending_queue is full",
+			Present: false,
+		},
+		resultsSummary,
+		testbed.WithResourceLimits(resourceSpec),
+	)
+	tc.MockBackend.EnableRecording()
+	defer tc.Stop()
+
+	tc.StartBackend()
+	tc.StartAgent()
+
+	tc.StartLoad(loadOptions)
+
+	tc.Sleep(time.Second * time.Duration(sleepTime))
+
+	tc.WaitFor(func() bool { return tc.LoadGenerator.DataItemsSent() > 0 }, "load generator started")
+
+	tc.WaitForN(func() bool { return tc.LoadGenerator.DataItemsSent() == tc.MockBackend.DataItemsReceived() }, time.Second*time.Duration(sleepTime),
+		"all spans received")
+
+	tc.StopLoad()
+	tc.StopAgent()
+	tc.ValidateData()
+}
+
 func constructLoadOptions(test TestCase) testbed.LoadOptions {
 	options := testbed.LoadOptions{DataItemsPerSecond: 1000, ItemsPerBatch: 10}
 	options.Attributes = make(map[string]string)
@@ -315,4 +453,37 @@ func constructLoadOptions(test TestCase) testbed.LoadOptions {
 		options.Attributes[attrName] = genRandByteString(rand.Intn(test.attrSizeByte*2-1) + 1)
 	}
 	return options
+}
+
+func getLogsId(logToRetry []plog.Logs) []string {
+	var result []string
+	for _, logElement := range logToRetry {
+		logRecord := logElement.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+		for index := 0; index < logRecord.Len(); index++ {
+			logObj := logRecord.At(index)
+			itemIndex, _ := logObj.Attributes().Get("item_index")
+			batchIndex, _ := logObj.Attributes().Get("batch_index")
+			result = append(result, fmt.Sprintf("%s%s", batchIndex.AsString(), itemIndex.AsString()))
+		}
+	}
+	return result
+}
+
+func allElementsExistInSlice(slice1, slice2 []string) bool {
+	// Create a map to store elements of slice2 for efficient lookup
+	elementMap := make(map[string]bool)
+
+	// Populate the map with elements from slice2
+	for _, element := range slice2 {
+		elementMap[element] = true
+	}
+
+	// Check if all elements of slice1 exist in slice2
+	for _, element := range slice1 {
+		if _, exists := elementMap[element]; !exists {
+			return false
+		}
+	}
+
+	return true
 }

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -362,7 +362,7 @@ func ScenarioSendingQueuesFull(
 			dataChannel <- true
 			return false
 		}
-		tc.WaitFor(func() bool { return tc.MockBackend.DataItemsReceived() == 0 }, "any data items received successfully")
+		tc.WaitFor(func() bool { return tc.MockBackend.DataItemsReceived() == 0 }, "no data successfully received before an error")
 		close(dataChannel)
 		return logFound
 	}, time.Second*time.Duration(sleepTime), "sending_queue errors present")
@@ -370,7 +370,7 @@ func ScenarioSendingQueuesFull(
 	// check if data started to be received successfully
 	tc.WaitForN(func() bool {
 		return tc.MockBackend.DataItemsReceived() > 0
-	}, time.Second*time.Duration(sleepTime), "data was accepted")
+	}, time.Second*time.Duration(sleepTime), "data started to be successfully received")
 
 	tc.WaitForN(func() bool {
 		// get IDs from logs to retry
@@ -382,7 +382,7 @@ func ScenarioSendingQueuesFull(
 		// check if all the logs to retry were actually retried
 		logsWereRetried := allElementsExistInSlice(logsToRetry, successfulLogs)
 		return logsWereRetried
-	}, time.Second*time.Duration(sleepTime), "all logs were retried")
+	}, time.Second*time.Duration(sleepTime), "all logs were retried successfully")
 
 	tc.StopLoad()
 	tc.StopAgent()
@@ -423,7 +423,6 @@ func ScenarioSendingQueuesNotFull(
 		resultsSummary,
 		testbed.WithResourceLimits(resourceSpec),
 	)
-	tc.MockBackend.EnableRecording()
 	defer tc.Stop()
 
 	tc.StartBackend()

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -357,7 +357,7 @@ func ScenarioSendingQueuesFull(
 	// searchFunc checks for "sending_queue is full" communicate and sends the signal to GenerateNonPernamentErrorUntil
 	// to generate only successes from that time on
 	tc.WaitForN(func() bool {
-		logFound := tc.SearchText("sending_queue is full")
+		logFound := tc.AgentLogsContains("sending_queue is full")
 		if !logFound {
 			dataChannel <- true
 			return false


### PR DESCRIPTION
**Description:** This PR adds two tests with an otlp receiver and exporter with sending queues. We have two scenarios here:

Sending queue full
1. We generate permanent errors until `sending_queue is full` log appears in the agent's logs
2. Then we get IDs of logs meant to be retried and IDs of logs received successfully and check if all of them were retried

The current testbed is unable to get the information about the errors from load generator's perspective, so I needed to put `LogsToRetry` in `mock_backend` to be able to track what logs suffered from permanent error. 

Sending queue not full
Sanity test to check a default behavior of sending queue, but without making it full.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>